### PR TITLE
Added option to filter discounted items only

### DIFF
--- a/Firefox/contentScript.js
+++ b/Firefox/contentScript.js
@@ -9,6 +9,7 @@ let settings = {
   watchThreshold: 10,
   appraisalFilterEnabled: false,
   appraisalThreshold: 0,
+  appraisalDiscountedOnly: false,
   paintSeedFilterEnabled: false,
   allowedPaintSeeds: "127"
 };
@@ -95,6 +96,14 @@ function checkAppraisal(card) {
     if (!appraisalElem) return false;
     const match = appraisalElem.textContent.trim().match(/-?\d+(\.\d+)?/);
     if (!match) return false;
+
+    // We determine if the item is discounted by the color of the appraisal circle
+    let circles = card.querySelectorAll('.reference svg.ng-star-inserted circle');
+    if (circles) {
+      if (circles.length !== 1) return false; // If this is not 1, the search has probably failed
+      if (circles[0].getAttribute('fill') !== '#64EC42' && settings.appraisalDiscountedOnly) return true;
+    }
+    
     const appraisalValue = parseFloat(match[0]);
     return appraisalValue < settings.appraisalThreshold;
   } catch (error) {

--- a/Firefox/popup.html
+++ b/Firefox/popup.html
@@ -78,6 +78,13 @@
     .switch input:checked + .sliderToggle:before {
       transform: translateX(18px);
     }
+    .default-checkbox {
+      appearance: auto;
+      position: static;
+      opacity: 1;
+      width: auto;
+      height: auto;
+    }
   </style>
 </head>
 <body>
@@ -193,6 +200,10 @@
              step="1"
              value="0" />
     </div>
+    <label>
+      <input type="checkbox" class="default-checkbox" id="toggleAppraisalDiscountedOnly" />
+      Only display items below the appraisal price
+    </label>
   </div>
 
   <!-- Paint Seed Filter Card -->

--- a/Firefox/popup.js
+++ b/Firefox/popup.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     watchThreshold: 10,
     appraisalFilterEnabled: false,
     appraisalThreshold: 0,
+    appraisalDiscountedOnly: false,
     paintSeedFilterEnabled: false,
     allowedPaintSeeds: "127"
   };
@@ -25,7 +26,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     { checkboxId: 'toggleFadeFilterSwitch',    key: 'fadeFilterEnabled' },
     { checkboxId: 'toggleWatchFilterSwitch',   key: 'watchFilterEnabled' },
     { checkboxId: 'toggleAppraisalFilterSwitch', key: 'appraisalFilterEnabled' },
-    { checkboxId: 'togglePaintSeedFilterSwitch', key: 'paintSeedFilterEnabled' }
+    { checkboxId: 'togglePaintSeedFilterSwitch', key: 'paintSeedFilterEnabled' },
+    { checkboxId: 'toggleAppraisalDiscountedOnly', key: 'appraisalDiscountedOnly' }
   ];
 
   toggleMappings.forEach(({ checkboxId, key }) => {

--- a/contentScript.js
+++ b/contentScript.js
@@ -11,6 +11,7 @@
     watchThreshold: 10,
     appraisalFilterEnabled: false,
     appraisalThreshold: 100,
+    appraisalDiscountedOnly: false,
     paintSeedFilterEnabled: false,
     allowedPaintSeeds: "127"
   };
@@ -131,6 +132,14 @@
       if (!appraisalElem) return false;
       const appraisalText = appraisalElem.textContent.replace(/[^\d.]/g, '').trim();
       if (!appraisalText) return false;
+
+      // We determine if the item is discounted by the color of the appraisal circle
+      let circles = card.querySelectorAll('.reference svg.ng-star-inserted circle');
+      if (circles) {
+        if (circles.length !== 1) return false; // If this is not 1, the search has probably failed
+        if (circles[0].getAttribute('fill') !== '#64EC42' && settings.appraisalDiscountedOnly) return true;
+      }
+
       const appraisalValue = parseFloat(appraisalText);
       return appraisalValue < settings.appraisalThreshold;
     } catch (error) {

--- a/popup.html
+++ b/popup.html
@@ -78,6 +78,13 @@
       transition: .4s;
       border-radius: 50%;
     }
+    .default-checkbox {
+      appearance: auto;
+      position: static;
+      opacity: 1;
+      width: auto;
+      height: auto;
+    }
   </style>
 </head>
 <body>
@@ -193,6 +200,10 @@
            step="1"
            value="0" />
   </div>
+  <label>
+    <input type="checkbox" class="default-checkbox" id="toggleAppraisalDiscountedOnly" />
+    Only display items below the appraisal price
+  </label>
 </div>
 
 

--- a/popup.js
+++ b/popup.js
@@ -4,7 +4,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     { checkboxId: 'toggleStickerFilterSwitch', key: 'stickerFilterEnabled' },
     { checkboxId: 'toggleFadeFilterSwitch', key: 'fadeFilterEnabled' },
     { checkboxId: 'toggleWatchFilterSwitch', key: 'watchFilterEnabled' },
-    { checkboxId: 'toggleAppraisalFilterSwitch', key: 'appraisalFilterEnabled' }
+    { checkboxId: 'toggleAppraisalFilterSwitch', key: 'appraisalFilterEnabled' },
+    { checkboxId: 'toggleAppraisalDiscountedOnly', key: 'appraisalDiscountedOnly' }
   ];
 
   // Existing slider definitions for other filters...
@@ -25,6 +26,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     watchThreshold: 10,
     appraisalFilterEnabled: false,
     appraisalThreshold: 0,
+    appraisalDiscountedOnly: false,
     paintSeedFilterEnabled: false,
     allowedPaintSeeds: "127"
   });
@@ -93,6 +95,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       watchThreshold: 10,
       appraisalFilterEnabled: false,
       appraisalThreshold: 0,
+      appraisalDiscountedOnly: false,
       paintSeedFilterEnabled: false,
       allowedPaintSeeds: "127"
     });


### PR DESCRIPTION
Currently the appraisal price filtering checks only if the discount value is bigger than the absolute value of the discount. This adds an option to only view actually discounted items.